### PR TITLE
Alias sub-command shortens common commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,8 @@ alias.
 
 ...
 aliases:
-  - name: complete
-    command: "State: Complete"
-  - name: mine
-    command: "Assigned to : me"
+  complete: "State: Complete"
+  mine: "Assigned to: me"
 ```
 
 Then, you can simply specify the alias as the command (with an optional comment

--- a/README.md
+++ b/README.md
@@ -92,6 +92,31 @@ $ goutrack c yt-1234 "Assignee me" "I'll take this story."
 $ goutrack c yt-4321 "Subsystem server-side"
 ```
 
+## Aliases
+
+GouTrack has aliases which can shorten frequently used commands. Simply define
+a set of aliases in your config file and use the `a` sub-command to expand the
+alias.
+
+```
+# ~/.goutrack
+
+...
+aliases:
+  - name: complete
+    command: "State: Complete"
+  - name: mine
+    command: "Assigned to : me"
+```
+
+Then, you can simply specify the alias as the command (with an optional comment
+string).
+
+```
+$ goutrack a c-1234 complete
+Applying State: Complete to c-1234
+```
+
 ## Contributing
 
 When contributing please

--- a/main.go
+++ b/main.go
@@ -24,6 +24,12 @@ type Config struct {
 	Host     string
 	Username string
 	Password string
+	Aliases  []Alias
+}
+
+type Alias struct {
+	Name    string
+	Command string
 }
 
 func main() {
@@ -49,7 +55,25 @@ func main() {
 	case "c":
 		fmt.Println("Applying", *commandString, "to", *story)
 		fmt.Println(client.CommandIssue(*story, *commandString, *commentString))
+	case "a":
+		command := config.getCommandFromAlias(*commandString)
+		if command != "" {
+			fmt.Println("Applying", command, "to", *story)
+			fmt.Println(client.CommandIssue(*story, command, *commentString))
+		} else {
+			fmt.Println("Alias:", *commandString, "not found")
+		}
 	}
+}
+
+func (config Config) getCommandFromAlias(name string) string {
+	for _, alias := range config.Aliases {
+		if alias.Name == name {
+			return alias.Command
+		}
+	}
+
+	return ""
 }
 
 func readConfigFromFile() Config {

--- a/main.go
+++ b/main.go
@@ -24,12 +24,7 @@ type Config struct {
 	Host     string
 	Username string
 	Password string
-	Aliases  []Alias
-}
-
-type Alias struct {
-	Name    string
-	Command string
+	Aliases  map[string]string
 }
 
 func main() {
@@ -67,13 +62,7 @@ func main() {
 }
 
 func (config Config) getCommandFromAlias(name string) string {
-	for _, alias := range config.Aliases {
-		if alias.Name == name {
-			return alias.Command
-		}
-	}
-
-	return ""
+	return config.Aliases[name]
 }
 
 func readConfigFromFile() Config {


### PR DESCRIPTION
## Aliases

GouTrack has aliases which can shorten frequently used commands. Simply define
a set of aliases in your config file and use the `a` sub-command to expand the
alias.

```
# ~/.goutrack

...
aliases:
  complete: "State: Complete"
  mine: "Assigned to : me"
```

Then, you can simply specify the alias as the command (with an optional comment
string).

```
$ goutrack a c-1234 complete
Applying State: Complete to c-1234
```
